### PR TITLE
Fix TypeError when deserializing a Transaction

### DIFF
--- a/palantir/datasets/rpc/catalog.py
+++ b/palantir/datasets/rpc/catalog.py
@@ -570,7 +570,7 @@ class Transaction(ConjureBeanType):
                 "permissionPath", OptionalTypeWrapper[str]
             ),
             "record": ConjureFieldDefinition(
-                "record", OptionalTypeWrapper[DictType(str, Any)]  # type: ignore
+                "record", OptionalTypeWrapper[dict]  # type: ignore
             ),
             "attribution": ConjureFieldDefinition(
                 "attribution", OptionalTypeWrapper[Attribution]


### PR DESCRIPTION
The current type throws an error:
```TypeError: Parameters to generic types must be types. Got <conjure_python_client._lib.types.DictType object at 0x103319d90>.```