### PR TITLE
Return an IOBase object in file.read()

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: |-
+    Return an IOBase object in file.read()
+
+    Instead of returning all bytes, we should return the IOBase object to grant more flexibility to the user
+  links:
+  - https://github.com/palantir/palantir-python-sdk/pull/22

--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,8 +1,6 @@
 type: break
 break:
   description: |-
-    Return an IOBase object in file.read()
-
-    Instead of returning all bytes, we should return the IOBase object to grant more flexibility to the user
+    Return an IOBase object in file.read() instead of reading all bytes
   links:
   - https://github.com/palantir/palantir-python-sdk/pull/22

--- a/palantir/datasets/core.py
+++ b/palantir/datasets/core.py
@@ -276,7 +276,7 @@ class File:
 
     def read(self) -> io.IOBase:
         """Returns: A binary stream of the file content."""
-        return self.client.read_file(self.locator()).read()
+        return self.client.read_file(self.locator())
 
     def write(
         self,


### PR DESCRIPTION
Instead of returning all bytes, we should return the IOBase object to grant more flexibility to the user