### PR TITLE
Minor improvements

### DIFF
--- a/palantir/core/types.py
+++ b/palantir/core/types.py
@@ -31,7 +31,7 @@ _rid_pattern: Pattern = re.compile(
     "\\.(?P<service>[a-z][a-z0-9\\-]*)"
     "\\.(?P<instance>[a-z0-9][a-z0-9\\-]*)?"
     "\\.(?P<type>[a-z][a-z0-9\\-]*)"
-    "\\.(?P<locator>[a-zA-Z0-9_\\-\\.]+)"
+    "\\.(?P<locator>[a-zA-Z0-9_\\-.]+)"
 )
 
 
@@ -89,7 +89,7 @@ class ResourceIdentifier:
         Returns a ResourceIdentifier object if the value can be parsed as a resource identifier
         or raises an error.
         """
-        match = _rid_pattern.match(value)
+        match = _rid_pattern.fullmatch(value)
         if match:
             return ResourceIdentifier(
                 service=match.group("service"),

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import ast
 import subprocess
 
 try:
@@ -20,7 +21,13 @@ try:
         .strip()
         .replace("-", "_")
     )
-    open("palantir/_version.py", "w").write('__version__ = "{}"\n'.format(gitversion))
-except subprocess.CalledProcessError:
-    print("outside git repo, not generating new version string")
-exec(open("palantir/_version.py").read())
+except subprocess.CalledProcessError as exc:
+    raise Exception("outside git repo, not generating new version string") from exc
+
+file_content = f"__version__ = {repr(gitversion)}\n"
+
+# raise error if the syntax of the generated file is incorrect:
+x = ast.parse(file_content)
+
+with open("palantir/_version.py", "w") as version_file:
+    version_file.write(file_content)


### PR DESCRIPTION
- potentially safer `ast.parse` instead of `exec` (if I understand the purpose of `exec` there correctly)
- raise error if can't find the version 
- more precise RID matching